### PR TITLE
Add slide in and slide out functionality to login and register modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,23 +2,6 @@
   text-align: center;
 }
 
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 40vmin;
-  pointer-events: none;
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
 .App-link {
   color: #61dafb;
 }
@@ -30,11 +13,31 @@
 .modal-title {
   width: 100%;
 }
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+
+@-webkit-keyframes slide-in {
+  0% { right: -400px; }
+  100% { right: 0; }
+}
+
+@keyframes slide-out {
+  0% { right: 0; }
+  100% { right: -500px; }
+}
+
+.modal.right .modal-dialog {
+  animation: slide-in 1.0s forwards;
+  position: fixed;
+  margin: auto;
+  height: 100%;
+  -webkit-transform: translate3d(0%, 0, 0);
+  -ms-transform: translate3d(0%, 0, 0);
+  -o-transform: translate3d(0%, 0, 0);
+  transform: translate3d(0%, 0, 0);
+}
+
+.modal.right .modal-content {
+  height: 100%;
+  overflow-y: auto;
+  border: none;
+  border-radius: 0;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,6 @@ import Chat from './pages/Chat.js'
 import Geolocation from './pages/Geolocation'
 import MapJ from './pages/MapJ.js'
 import aunty from './images/aunty.jpg'
-import './App.css';
 
 class App extends Component {
   render() {

--- a/src/containers/Login.js
+++ b/src/containers/Login.js
@@ -89,7 +89,7 @@ export default class Login extends React.Component{
                 </AvForm>
             </ModalBody>
             <ModalFooter>
-                <Button form="login" color="primary" type="submit">Login</Button>
+                <Button className="btn-lg" form="login" color="primary" type="submit">Login</Button>
             </ModalFooter>
         </>
         )

--- a/src/containers/LoginModal.js
+++ b/src/containers/LoginModal.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Modal, ModalHeader, TabContent, TabPane, Nav, NavItem, NavLink } from 'reactstrap';
 import classnames from 'classnames';
-import Register from '../containers/Register'
-import Login from '../containers/Login'
+import Register from './Register'
+import Login from './Login'
 import { withToastManager } from 'react-toast-notifications';
 
 const RegisterToasts = withToastManager(Register);
@@ -28,28 +28,28 @@ export default class LoginModal extends React.Component {
 
   render() {
     return (
-      <Modal isOpen={this.props.isOpen} toggle={this.props.toggle} className={this.props.className}>
-      <ModalHeader toggle={this.props.toggle}>
-        <Nav tabs>
-          <NavItem>
-            <NavLink
-              className={classnames({ active: this.state.activeTab === '1' })}
-              onClick={() => { this.switch('1'); }}
-            >
-              Register
-            </NavLink>
-          </NavItem>
-          <NavItem>
-            <NavLink
-              className={classnames({ active: this.state.activeTab === '2' })}
-              onClick={() => { this.switch('2'); }}
-            >
-              Login
-            </NavLink>
-          </NavItem>
-        </Nav>
-      </ModalHeader>
-      <TabContent activeTab={this.state.activeTab}>
+      <Modal isOpen={this.props.isOpen} toggle={this.props.toggle} modalClassName="right" fade={false}>
+        <ModalHeader toggle={this.props.toggle}>
+          <Nav tabs>
+            <NavItem>
+              <NavLink
+                className={classnames({ active: this.state.activeTab === '1' })}
+                onClick={() => { this.switch('1'); }}
+              >
+                Register
+              </NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink
+                className={classnames({ active: this.state.activeTab === '2' })}
+                onClick={() => { this.switch('2'); }}
+              >
+                Login
+              </NavLink>
+            </NavItem>
+          </Nav>
+        </ModalHeader>
+        <TabContent activeTab={this.state.activeTab}>
           <TabPane tabId="1">
             <RegisterToasts toggle={this.props.toggle}/>
           </TabPane>

--- a/src/containers/Register.js
+++ b/src/containers/Register.js
@@ -164,7 +164,7 @@ export default class Register extends React.Component {
                     </AvForm>
                 </ModalBody>
                 <ModalFooter>
-                    <Button form="register" color="primary" type="submit">Register</Button>
+                    <Button className="btn-lg" form="register" color="primary" type="submit">Register</Button>
                 </ModalFooter>
             </>
         )

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import './App.css';
 import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,32 +1,42 @@
 import React from "react";
 import { Link } from 'react-router-dom';
 import { Button } from 'reactstrap';
-import Modal from '../containers/Modal'
+import LoginModal from '../containers/LoginModal'
 
 class Homepage extends React.Component {
   constructor(props) {
       super(props);
       this.state = {
-          modal: false
+          modal: false,
       };
       this.showModal = this.showModal.bind(this);
   }
 
     showModal = () => {
-        this.setState(prevState => ({
-            modal: !prevState.modal
-        }));
+        // This is a hacky solution to apply slide-out animation to a specific motion (close out of a reactstrap modal). Although it works, it is not recommended. We can remove this if we only want slide-in motion.
+        if (this.state.modal) {
+            document.querySelector(".modal.right .modal-dialog").style.animation = "slide-out 1.0s forwards"
+            setTimeout(() => {
+                this.setState(prevState => ({
+                    modal: !prevState.modal
+                }));
+            }, 1000);
+        } else {
+            this.setState(prevState => ({
+                modal: !prevState.modal
+            }));
+        }
     }
 
     render() {
         return (
             <div>
-            <Link to="/chat">Chat with Aunty</Link> <br />
-            <Link to="/geolocation">Geolocation</Link> <br />
-            <Link to="/mapj">Jade's Map</Link> <br /> <br />
-            <Button outline color="primary" onClick={this.showModal}>Register / Login</Button>
-            <p>This is the home page. <br/>Wait ah, Aunty still building.</p>
-            <Modal isOpen={this.state.modal} toggle={this.showModal}/>
+                <Link to="/chat">Chat with Aunty</Link> <br />
+                <Link to="/geolocation">Geolocation</Link> <br />
+                <Link to="/mapj">Jade's Map</Link> <br /> <br />
+                <Button outline color="primary" onClick={this.showModal}>Register / Login</Button>
+                <p>This is the home page. <br/>Wait ah, Aunty still building.</p>
+                <LoginModal isOpen={this.state.modal} toggle={this.showModal}/>
             </div>
         )
     }


### PR DESCRIPTION
- Adding slide in and slide out transition functionality to reactstrap modal for login/register forms. 
- It is possible to achieve slide-in functionality with use of keyframes, however, reactstrap uses "display: none" to make a modal fade out. To work around this, added a hacky conditional on HomePage to apply special animation if the modal state is true. Although it works, it's not recommended to mix in this type of vanilla JS in React. I've already spent enough time on this, so I will think about this later next week to refactor.